### PR TITLE
Update CheckBlenderVersion()

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -117,9 +117,8 @@ TextureTypeLookup = {
 
 def CheckBlenderVersion():
     global OnCorrectBlenderVersion
-    BlenderVersion = bpy.app.version_string
-    version = BlenderVersion.split(".")
-    OnCorrectBlenderVersion = (version[0] == "4" and version[1] == "0")
+    BlenderVersion = bpy.app.version
+    OnCorrectBlenderVersion = (BlenderVersion[0] == 4 and BlenderVersion[1] == 0)
     PrettyPrint(f"Blender Version: {BlenderVersion} Correct Version: {OnCorrectBlenderVersion}")
 
 def PrettyPrint(msg, type="info"): # Inspired by FortnitePorting


### PR DESCRIPTION
changed it to use numbers instead of strings, would be usefull if you also wanna check some other verisons that might be compatible so that you dont have to downgrade to 4.0 for the modding sdk to work