### PR TITLE
added compatibility for blender 4.3

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,9 +25,7 @@ Community Edition aims to bring quality of life features to the Helldivers 2 Mod
 The developers of the original version of the tool have stated that they are unlikely to update it. Therefore, this community version of it has been made to bring quality of life features and to fix issues with the base version of the tool.
 
 ## Installation
-Download the [latest release build](https://github.com/Boxofbiscuits97/HD2SDK-CommunityEdition/releases) and install it into [Blender 4.0](https://www.blender.org/download/previous-versions/). Windows is the only supported operating system.
-> [!IMPORTANT]
-> <ins>**You MUST use Blender 4.0**</ins> due to API changes is Blender 4.1 and onward that break the tool.
+Download the [latest release build](https://github.com/Boxofbiscuits97/HD2SDK-CommunityEdition/releases) and install it into [Blender 4.x](https://www.blender.org/download/). Windows is the only supported operating system.
 
 ## Usage
 We've taken the time to write a tutorial focused on armor modding which should assist those already moderately familiar with mesh modding and Blender in general. Unfortunately we do not have the means to provide constant support to anyone new to either, but in the event anyone should write a more in-depth tutorial, create a video tutorial, etc, we would be happy to feature it here if it's brought to our attention.

--- a/__init__.py
+++ b/__init__.py
@@ -2459,14 +2459,17 @@ class StingrayMeshFile:
             self.SetupRawMeshComponents(OrderedMeshes)
 
         # Serialize Gpu Data
-        for stream_idx in range(len(OrderedMeshes)):
-            Stream_Info = self.StreamInfoArray[stream_idx]
-            if gpu.IsReading():
-                self.SerializeIndexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
-                self.SerializeVertexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
-            else:
-                self.SerializeVertexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
-                self.SerializeIndexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
+        # for some reason you only seem to need index 0, some meshes break with more
+        # TODO: Figure out why data gets deleted on more passes and figure out what the other indices even do
+        # for stream_idx in range(len(OrderedMeshes)):
+        stream_idx = 0
+        Stream_Info = self.StreamInfoArray[stream_idx]
+        if gpu.IsReading():
+            self.SerializeIndexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
+            self.SerializeVertexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
+        else:
+            self.SerializeVertexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
+            self.SerializeIndexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
 
     def SerializeIndexBuffer(self, gpu, Stream_Info, stream_idx, OrderedMeshes):
         # get indices

--- a/__init__.py
+++ b/__init__.py
@@ -115,11 +115,11 @@ TextureTypeLookup = {
 
 #region Functions: Miscellaneous
 
+# 4.3 compatibility change
 def CheckBlenderVersion():
     global OnCorrectBlenderVersion
-    BlenderVersion = bpy.app.version_string
-    version = BlenderVersion.split(".")
-    OnCorrectBlenderVersion = (version[0] == "4" and version[1] == "0")
+    BlenderVersion = bpy.app.version
+    OnCorrectBlenderVersion = (BlenderVersion[0] == 4 and 3 >= BlenderVersion[1] >= 0)
     PrettyPrint(f"Blender Version: {BlenderVersion} Correct Version: {OnCorrectBlenderVersion}")
 
 def PrettyPrint(msg, type="info"): # Inspired by FortnitePorting
@@ -308,6 +308,9 @@ def GetMeshData(og_object):
 
     # get normals, tangents, bitangents
     #mesh.calc_tangents()
+    # 4.3 compatibility change
+    if not mesh.has_custom_normals:
+        mesh.create_normals_split()
     mesh.calc_normals_split()
     for loop in mesh.loops:
         normals[loop.vertex_index]    = loop.normal.normalized()
@@ -483,7 +486,12 @@ def CreateModel(model, id, customization_info, bone_names):
         new_collection.objects.link(new_object)
         # -- || ASSIGN NORMALS || -- #
         if len(mesh.VertexNormals) == len(mesh.VertexPositions):
-            new_mesh.use_auto_smooth = True
+            # 4.3 compatibility change
+            if bpy.app.version[0]>=4 and bpy.app.version[1]>=1:
+                new_mesh.shade_smooth()
+            else:
+                new_mesh.use_auto_smooth = True
+            
             new_mesh.polygons.foreach_set('use_smooth',  [True] * len(new_mesh.polygons))
             if not isinstance(mesh.VertexNormals[0], int):
                 new_mesh.normals_split_custom_set_from_vertices(mesh.VertexNormals)

--- a/__init__.py
+++ b/__init__.py
@@ -309,9 +309,11 @@ def GetMeshData(og_object):
     # get normals, tangents, bitangents
     #mesh.calc_tangents()
     # 4.3 compatibility change
-    if not mesh.has_custom_normals:
-        mesh.create_normals_split()
-    mesh.calc_normals_split()
+    if bpy.app.version[0]>=4 and bpy.app.version[1]<1:
+        if not mesh.has_custom_normals:
+            mesh.create_normals_split()
+        mesh.calc_normals_split()
+        
     for loop in mesh.loops:
         normals[loop.vertex_index]    = loop.normal.normalized()
         #tangents[loop.vertex_index]   = loop.tangent.normalized()

--- a/__init__.py
+++ b/__init__.py
@@ -2459,17 +2459,14 @@ class StingrayMeshFile:
             self.SetupRawMeshComponents(OrderedMeshes)
 
         # Serialize Gpu Data
-        # for some reason you only seem to need index 0, some meshes break with more
-        # TODO: Figure out why data gets deleted on more passes and figure out what the other indices even do
-        # for stream_idx in range(len(OrderedMeshes)):
-        stream_idx = 0
-        Stream_Info = self.StreamInfoArray[stream_idx]
-        if gpu.IsReading():
-            self.SerializeIndexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
-            self.SerializeVertexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
-        else:
-            self.SerializeVertexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
-            self.SerializeIndexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
+        for stream_idx in range(len(OrderedMeshes)):
+            Stream_Info = self.StreamInfoArray[stream_idx]
+            if gpu.IsReading():
+                self.SerializeIndexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
+                self.SerializeVertexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
+            else:
+                self.SerializeVertexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
+                self.SerializeIndexBuffer(gpu, Stream_Info, stream_idx, OrderedMeshes)
 
     def SerializeIndexBuffer(self, gpu, Stream_Info, stream_idx, OrderedMeshes):
         # get indices
@@ -2548,7 +2545,7 @@ class StingrayMeshFile:
                 if Mesh_Info.Sections[0].NumVertices != RealNumVerts:
                     for Section in Mesh_Info.Sections:
                         Section.NumVertices = RealNumVerts
-                    self.ReInitRawMeshVerts()
+                    self.ReInitRawMeshVerts(mesh)
 
     def SerializeVertexBuffer(self, gpu, Stream_Info, stream_idx, OrderedMeshes):
         # Vertex Buffer
@@ -2696,10 +2693,10 @@ class StingrayMeshFile:
             NewMesh.InitBlank(Mesh_Info.GetNumVertices(), Mesh_Info.GetNumIndices(), numUVs, numBoneIndices)
             self.RawMeshes.append(NewMesh)
     
-    def ReInitRawMeshVerts(self):
-        for mesh in self.RawMeshes:
-            Mesh_Info = self.MeshInfoArray[self.DEV_MeshInfoMap[mesh.MeshInfoIndex]]
-            mesh.ReInitVerts(Mesh_Info.GetNumVertices())
+    def ReInitRawMeshVerts(self, mesh):
+        # for mesh in self.RawMeshes:
+        Mesh_Info = self.MeshInfoArray[self.DEV_MeshInfoMap[mesh.MeshInfoIndex]]
+        mesh.ReInitVerts(Mesh_Info.GetNumVertices())
 
     def SetupRawMeshComponents(self, OrderedMeshes):
         for stream_idx in range(len(OrderedMeshes)):


### PR DESCRIPTION
changed the CheckBlenderVersion()
check for split normals before calculating said normals, seems to be required by the newer blender version
added a version check to set the smooth normals differently as newer blender versions dont have auto smooth

to be fair i'm quite new to python and blender plugins but i have tested it with making a mod, fully loading the base archive, editing an armor set, using different materials and textures and everything seems to be working fine, might need some more testing but i havent found any more issues with the new blender version. personally i'd be comfortable using this changes while making new mods on the newer blender version