### PR TITLE
Hash fixes

### DIFF
--- a/hashlists/archivehashes.json
+++ b/hashlists/archivehashes.json
@@ -347,7 +347,7 @@
 
     "Submachine Gun": {
         "0601a2f91ec178a9": "MP-98 Knight",
-        "f230d2d2adcc034a": "SMG-37 Defender & SMG-37 Defender",
+        "f230d2d2adcc034a": "SMG-37 Defender & StA-11 SMG",
         "0edad8ddec238bd9": "SMG-32 Reprimand",
         "5193b8a6d77f5a0a": "StA-11 SMG & SMG-72 Pummeler"
     },

--- a/hashlists/archivehashes.json
+++ b/hashlists/archivehashes.json
@@ -347,9 +347,9 @@
 
     "Submachine Gun": {
         "0601a2f91ec178a9": "MP-98 Knight",
-        "f230d2d2adcc034a": "SMG-72 Pummeler & SMG-37 Defender",
+        "f230d2d2adcc034a": "SMG-37 Defender & SMG-37 Defender",
         "0edad8ddec238bd9": "SMG-32 Reprimand",
-        "5193b8a6d77f5a0a": "StA-11 SMG"
+        "5193b8a6d77f5a0a": "StA-11 SMG & SMG-72 Pummeler"
     },
 
     "Melee": {


### PR DESCRIPTION
SDK Lists the Pummeler to be in the same archive as the defender, its not for some reason StA-11 is in both archive "f230d2d2adcc034a" with the defender and archive "5193b8a6d77f5a0a" with the pummeler. 