### PR TITLE
Fix bugs with armature editing and with exporting custom normals

### DIFF
--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1466,15 +1466,21 @@ def GetMeshData(og_object, Global_TocManager, Global_BoneNames):
                 m[3][0], m[3][1], m[3][2], m[3][3]
             ]
             transform_info.TransformMatrices[transform_index] = transform_matrix
-            translation, rotation, scale = bone.matrix.decompose()
-            rotation = rotation.to_matrix()
-            transform_local = StingrayLocalTransform()
-            transform_local.rot.x = [rotation[0][0], rotation[0][1], rotation[0][2]]
-            transform_local.rot.y = [rotation[1][0], rotation[1][1], rotation[1][2]]
-            transform_local.rot.z = [rotation[2][0], rotation[2][1], rotation[2][2]]
-            transform_local.pos = translation
-            transform_local.scale = scale
-            transform_info.Transforms[transform_index] = transform_local
+            if bone.parent:
+                parent_matrix = bone.parent.matrix
+                local_transform_matrix = parent_matrix.inverted() @ bone.matrix
+                translation, rotation, scale = local_transform_matrix.decompose()
+                rotation = rotation.to_matrix()
+                transform_local = StingrayLocalTransform()
+                transform_local.rot.x = [rotation[0][0], rotation[0][1], rotation[0][2]]
+                transform_local.rot.y = [rotation[1][0], rotation[1][1], rotation[1][2]]
+                transform_local.rot.z = [rotation[2][0], rotation[2][1], rotation[2][2]]
+                transform_local.pos = translation
+                transform_local.scale = scale
+                transform_info.Transforms[transform_index] = transform_local
+            else:
+                transform_local = StingrayLocalTransform()
+                transform_info.Transforms[transform_index] = transform_local
         bpy.context.view_layer.objects.active = prev_obj
         bpy.ops.object.mode_set(mode=prev_mode)
     #bpy.ops.object.mode_set(mode='OBJECT')

--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1795,8 +1795,10 @@ def CreateModel(model, id, customization_info, bone_names, transform_info, bone_
                             boneName = Global_BoneNames[boneHash]
                         else:
                             boneName = str(boneHash)
-                        newBone = armature.edit_bones.new(boneName)
-                        newBone.tail = 0, 0.0000025, 0
+                        newBone = armature.edit_bones.get(boneName)
+                        if newBone is None:
+                            newBone = armature.edit_bones.new(boneName)
+                            newBone.tail = 0, 0.0000025, 0
                         bones[i] = newBone
                         boneTransforms[newBone.name] = transform_info.Transforms[boneIndex]
                         boneMatrices[newBone.name] = transform_info.TransformMatrices[boneIndex]

--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1775,8 +1775,10 @@ def CreateModel(model, id, customization_info, bone_names, transform_info, bone_
                             boneName = Global_BoneNames[boneHash]
                         else:
                             boneName = str(boneHash)
-                        newBone = armature.edit_bones.new(boneName)
-                        newBone.tail = 0, 0.0000025, 0
+                        newBone = armature.edit_bones.get(boneName)
+                        if newBone is None:
+                            newBone = armature.edit_bones.new(boneName)
+                            newBone.tail = 0, 0.0000025, 0
                         bones[i] = newBone
                         boneParents[i] = boneParent
                         boneTransforms[newBone.name] = transform_info.Transforms[i]


### PR DESCRIPTION
- Use Darwin's octahedral encoding for importing/exporting compressed vertex normal data
  - No more C dll required
- Fix issue where local transform of bone was being computed incorrectly
  - Bones should now always appear in the correct places after editing
- Fix issue where not all bones were being imported
  - All bones are now imported onto the LOD 0 skeleton even if not specifically in the LOD bone data
- Add animation data to armature to support animation import