### PR TITLE
Update the SDK from within the SDK

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3483,7 +3483,7 @@ class AutoUpdateOperator(Operator):
         script_dir = os.path.dirname(os.path.abspath(__file__))
         zipfilepath = os.path.join(script_dir, "temp.zip")
         for item in os.listdir(script_dir):
-            item = os.path.join(item, script_dir)
+            item = os.path.join(script_dir, item)
             if os.path.isfile(item):
                 try:
                     os.remove(item)

--- a/__init__.py
+++ b/__init__.py
@@ -195,9 +195,15 @@ def CheckAddonUpToDate():
 
             global Global_addonUpToDate
             global Global_latestAddonVersion
-            Global_addonUpToDate = latestVersion == currentVersion
+            if latestVersion[0] > currentVersion[0]:
+                Global_addonUpToDate = False
+            elif latestVersion[0] == currentVersion[0] and latestVersion[1] > currentVersion[1]:
+                Global_addonUpToDate = False
+            elif latestVersion[0] == currentVersion[0] and latestVersion[1] == currentVersion[1] and latestVersion[2] > currentVersion[2]:
+                Global_addonUpToDate = False
+            else:
+                Global_addonUpToDate = True
             Global_latestAddonVersion = f"{latestVersion[0]}.{latestVersion[1]}.{latestVersion[2]}"
-
             if Global_addonUpToDate:
                 PrettyPrint("Addon is up to date!")
             else:

--- a/__init__.py
+++ b/__init__.py
@@ -20,6 +20,7 @@ import json
 import struct
 import concurrent.futures
 import zipfile
+import shutil
 
 #import pyautogui 
 
@@ -3481,6 +3482,18 @@ class AutoUpdateOperator(Operator):
             return {'CANCELLED'}
         script_dir = os.path.dirname(os.path.abspath(__file__))
         zipfilepath = os.path.join(script_dir, "temp.zip")
+        for item in os.listdir(script_dir):
+            item = os.path.join(item, script_dir)
+            if os.path.isfile(item):
+                try:
+                    os.remove(item)
+                except:
+                    pass
+            elif os.path.isdir(item):
+                try:
+                    shutil.rmtree(item)
+                except:
+                    pass
         with open(zipfilepath, "wb") as f:
             for chunk in r.iter_content(chunk_size=8192):
                 f.write(chunk)
@@ -3497,7 +3510,6 @@ class AutoUpdateOperator(Operator):
                 try:
                     with z.open(member) as source, open(destination_path, 'wb') as target:
                         target.write(source.read())
-                    print(f"Extracted: {member} to {destination_path}")
                 except:
                     pass
         z.close()


### PR DESCRIPTION
- If a user presses the "Out of date" button, it will now automatically install the update rather than directing them to download the update
How it works:
1. Fetch zip of latest version (hold in memory)
2. Delete all files in the addon directory
3. Write the zip to the addon directory
4. Unpack all files in the zip
5. Reload addons