### PR TITLE
Fix issue with importing certain meshes

### DIFF
--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1689,7 +1689,7 @@ def CreateModel(stingray_unit, id, Global_BoneNames):
                     available_bones.append(Global_BoneNames.get(h, str(h)))
             except IndexError:
                 pass
-        vertex_to_material_index = [0]*len(mesh.VertexPositions)
+        vertex_to_material_index = [5000]*len(mesh.VertexPositions)
         for mat_idx, mat in enumerate(mesh.Materials):
             for face in mesh.Indices[mat.StartIndex//3:(mat.StartIndex//3+mat.NumIndices//3)]:
                 for vert_idx in face:
@@ -1706,7 +1706,10 @@ def CreateModel(stingray_unit, id, Global_BoneNames):
                     weight_value = weights[weight_idx]
                     bone_index   = indices[weight_idx]
                     if not bpy.context.scene.Hd2ToolPanelSettings.LegacyWeightNames:
-                        hashIndex = bone_info[mesh.LodIndex].GetRealIndex(bone_index, vertex_to_material_index[vertex_idx])
+                        try:
+                            hashIndex = bone_info[mesh.LodIndex].GetRealIndex(bone_index, vertex_to_material_index[vertex_idx])
+                        except:
+                            continue
                         boneHash = transform_info.NameHashes[hashIndex]
                         group_name = Global_BoneNames.get(boneHash, str(boneHash))
                     else:


### PR DESCRIPTION
For some reason, it seems like when certain meshes are imported, there are a couple dozen vertices that are _not_ associated with any faces. The tool loops through all faces for each material and sets the material index for each vertex on that face, but some don't get set, and this breaks the import when trying to fetch the bone index from the remap for those vertices. Since they are, apparently, not part of any face of any material, it should be okay to just skip adding any weights from these vertices.