### PR TITLE
Add fix for UV islands messing up UV maps

### DIFF
--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1328,7 +1328,7 @@ def PrepareMesh(og_object):
     bmesh.ops.split_edges(bm, edges=boundary_seams)
     # update mesh
     bm.to_mesh(object.data)
-    bm.clear()
+    bm.free()
     # transfer normals
     modifier = object.modifiers.new("EXPORT_NORMAL_TRANSFER", 'DATA_TRANSFER')
     bpy.context.object.modifiers[modifier.name].data_types_loops = {'CUSTOM_NORMAL'}
@@ -1450,19 +1450,13 @@ def GetMeshData(og_object, Global_TocManager, Global_BoneNames):
     #LoadNormalPalette()
     #normals = NormalsFromPalette(normals)
     # get uvs
-    
-    #return
     for uvlayer in object.data.uv_layers:
         if len(uvs) >= 3:
             break
         texCoord = [[0,0] for vert in mesh.vertices]
         for face in object.data.polygons:
             for vert_idx, loop_idx in zip(face.vertices, face.loop_indices):
-                data = [uvlayer.data[loop_idx].uv[0], uvlayer.data[loop_idx].uv[1]*-1 + 1]
-                if texCoord[vert_idx] != [0, 0] and texCoord[vert_idx] != data:
-                    pass
-                else:
-                    texCoord[vert_idx] = [uvlayer.data[loop_idx].uv[0], uvlayer.data[loop_idx].uv[1]*-1 + 1]
+                texCoord[vert_idx] = [uvlayer.data[loop_idx].uv[0], uvlayer.data[loop_idx].uv[1]*-1 + 1]
         uvs.append(texCoord)
 
     # get weights


### PR DESCRIPTION
- Issue caused by vertices having multiple UV coordinates
- Issue fixed by effectively duplicating vertices and giving 1 UV coordinate to each one
- How it works:
  - Check for conflicts in active UV layer (if any vertex has more than 1 UV coord)
  - If conflict(s), choose a conflicting vertex and select all faces (and all those faces' vertices) that share a UV coord for that conflicting vertex
  - Split the selected section from the mesh, then merge by distance all selected vertices except the conflicting vertex
  - The result is that this splits just the conflicting vertex into 2 vertices, each with a separate UV coordinate and the same XYZ/normal data, and each attached to the appropriate faces
  - Repeat the entire process until there are no conflicts (must redo checking for conflicts because face/vertex indexes change due to splitting/merging)