### PR TITLE
Fix issue with ID swapping not working

### DIFF
--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1480,11 +1480,11 @@ def GetMeshData(og_object, Global_TocManager, Global_BoneNames):
     vert_idx = 0
     numInfluences = 4
     entry_id = int(og_object["Z_ObjectID"])
-    if hasattr(og_object, "Z_SwapID"):
-        entry_id = int(og_object["Z_SwapID"])
-        PrettyPrint(f"ID Swapping entry to ID: {entry_id}")
-    else:
-        PrettyPrint(f"Skipping ID swap for object as it has not Z_SwapID property", 'warn')
+    try:
+        if og_object["Z_SwapID"]:
+            entry_id = int(og_object["Z_SwapID"])
+    except KeyError:
+        pass
     stingray_mesh_entry = Global_TocManager.GetEntry(entry_id, int(UnitID), IgnorePatch=False, SearchAll=True)
     if stingray_mesh_entry:
         if not stingray_mesh_entry.IsLoaded: stingray_mesh_entry.Load(True, False)


### PR DESCRIPTION
- Issue was that `hasattr` would always return False, need to use dict lookup to get attribute. This would cause the SDK to always use the original Entry ID instead of the Swap ID (when available) to fetch the entry when writing the bone data in GetMeshData