### PR TITLE
Bug fixes also bones ig cuz my dumbass didn't put that on a separate branch

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -21,6 +21,7 @@ import struct
 import concurrent.futures
 import zipfile
 import shutil
+import importlib
 
 #import pyautogui 
 
@@ -29,6 +30,27 @@ import bpy
 from bpy_extras.io_utils import ImportHelper, ExportHelper
 from bpy.props import StringProperty, BoolProperty, IntProperty, EnumProperty, PointerProperty, CollectionProperty
 from bpy.types import Panel, Operator, PropertyGroup, Scene, Menu, OperatorFileListElement
+
+# other addon code
+from .stingray import animation as animation_m
+from .stingray import raw_dump as raw_dump_m
+from .stingray import material as material_m
+from .stingray import texture as texture_m
+from .stingray import particle as particle_m
+from .stingray import bones as bones_m
+from .stingray import composite_unit as composite_unit_m
+from .stingray import unit as unit_m
+from .hashlists import hash as hash_m
+
+importlib.reload(animation_m)
+importlib.reload(raw_dump_m)
+importlib.reload(material_m)
+importlib.reload(texture_m)
+importlib.reload(particle_m)
+importlib.reload(bones_m)
+importlib.reload(composite_unit_m)
+importlib.reload(unit_m)
+importlib.reload(hash_m)
 
 from .stingray.animation import StingrayAnimation, AnimationException
 from .stingray.raw_dump import StingrayRawDump

--- a/__init__.py
+++ b/__init__.py
@@ -3885,6 +3885,7 @@ class Hd2ToolPanelSettings(PropertyGroup):
     ImportArmature   : BoolProperty(name="Import Armatures", description = "Import unit armature data", default = True)
     MergeArmatures   : BoolProperty(name="Merge Armatures", description = "Merge new armatures to the selected armature", default = True)
     ParentArmature   : BoolProperty(name="Parent Armatures", description = "Make imported armatures the parent of the imported mesh", default = True)
+    SplitUVIslands   : BoolProperty(name="Split UV Islands", description = "Split mesh by UV islands when saving", default = False)
     # Search
     SearchField      : StringProperty(default = "")
 
@@ -4060,6 +4061,7 @@ class HellDivers2ToolsPanel(Panel):
             row.prop(scene.Hd2ToolPanelSettings, "SaveTexturesWithMaterial")
             row.prop(scene.Hd2ToolPanelSettings, "GenerateRandomTextureIDs")
             row.prop(scene.Hd2ToolPanelSettings, "OnlySaveCustomTextures")
+            row.prop(scene.Hd2ToolPanelSettings, "SplitUVIslands")
             row = mainbox.row(); row.separator(); row.label(text="Other Options"); box = row.box(); row = box.grid_flow(columns=1)
             row.prop(scene.Hd2ToolPanelSettings, "SaveNonSDKMaterials")
             row.prop(scene.Hd2ToolPanelSettings, "SaveUnsavedOnWrite")

--- a/__init__.py
+++ b/__init__.py
@@ -3885,7 +3885,6 @@ class Hd2ToolPanelSettings(PropertyGroup):
     ImportArmature   : BoolProperty(name="Import Armatures", description = "Import unit armature data", default = True)
     MergeArmatures   : BoolProperty(name="Merge Armatures", description = "Merge new armatures to the selected armature", default = True)
     ParentArmature   : BoolProperty(name="Parent Armatures", description = "Make imported armatures the parent of the imported mesh", default = True)
-    SplitUVIslands   : BoolProperty(name="Split UV Islands", description = "Attempt to split mesh by UV Islands when saving", default = False)
     # Search
     SearchField      : StringProperty(default = "")
 
@@ -4061,7 +4060,6 @@ class HellDivers2ToolsPanel(Panel):
             row.prop(scene.Hd2ToolPanelSettings, "SaveTexturesWithMaterial")
             row.prop(scene.Hd2ToolPanelSettings, "GenerateRandomTextureIDs")
             row.prop(scene.Hd2ToolPanelSettings, "OnlySaveCustomTextures")
-            row.prop(scene.Hd2ToolPanelSettings, "SplitUVIslands")
             row = mainbox.row(); row.separator(); row.label(text="Other Options"); box = row.box(); row = box.grid_flow(columns=1)
             row.prop(scene.Hd2ToolPanelSettings, "SaveNonSDKMaterials")
             row.prop(scene.Hd2ToolPanelSettings, "SaveUnsavedOnWrite")

--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1687,6 +1687,12 @@ def GetObjectsMeshData(Global_TocManager, Global_BoneNames):
         if object.type != 'MESH':
             continue
         ID = object["Z_ObjectID"]
+        try:
+            SwapID = object["Z_SwapID"]
+            if SwapID and SwapID.isnumeric():
+                ID = SwapID
+        except KeyError:
+            pass
         MeshData = GetMeshData(object, Global_TocManager, Global_BoneNames)
         try:
             data[ID][MeshData.MeshInfoIndex] = MeshData

--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1336,6 +1336,8 @@ def PrepareMesh(og_object):
             bpy.ops.uv.seams_from_islands()
         except: PrettyPrint("Failed to create seams from UV islands. This is not fatal, but will likely cause undesirable results in-game", "warn")
 
+    bpy.ops.object.mode_set(mode='OBJECT')
+
     bm = bmesh.new()
     bm.from_mesh(object.data)
 

--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1321,11 +1321,6 @@ def PrepareMesh(og_object):
     bpy.ops.object.select_all(action='DESELECT')
     bpy.context.view_layer.objects.active = object
     
-    # triangulate
-    modifier = object.modifiers.new("EXPORT_TRIANGULATE", 'TRIANGULATE')
-    bpy.context.object.modifiers[modifier.name].keep_custom_normals = True
-    bpy.ops.object.modifier_apply(modifier=modifier.name)
-    
     if bpy.context.scene.Hd2ToolPanelSettings.SplitUVIslands:
         # merge by distance
         bpy.ops.object.mode_set(mode='EDIT')
@@ -1362,6 +1357,11 @@ def PrepareMesh(og_object):
     bpy.context.object.modifiers[modifier.name].object = og_object
     bpy.context.object.modifiers[modifier.name].use_loop_data = True
     bpy.context.object.modifiers[modifier.name].loop_mapping = 'TOPOLOGY'
+    bpy.ops.object.modifier_apply(modifier=modifier.name)
+    
+    # triangulate
+    modifier = object.modifiers.new("EXPORT_TRIANGULATE", 'TRIANGULATE')
+    bpy.context.object.modifiers[modifier.name].keep_custom_normals = True
     bpy.ops.object.modifier_apply(modifier=modifier.name)
 
     # adjust weights


### PR DESCRIPTION
- Improve UV island fixing so it doesn't take forever
  - Use the Blender `seams_from_islands()` function
  - Split UV Islands option now controls whether or not a merge-by-distance is performed before the `seams_from_islands()`. Merge by distance seems to make UV island detection work properly on more complicated UV maps but I'm not sure if it has any downsides so it is left as an option.
- Fix issue where ID swapping 2 different meshes with different Swap IDs but the same original ID would not work
- Fix issue where ID swapping using the Save Unit button might not work
- Reload modules to ensure auto-update completes properly (Blender only reloads \_\_init\_\_.py by default)