### PR TITLE
Bug fixes

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3916,7 +3916,7 @@ class Hd2ToolPanelSettings(PropertyGroup):
     RemoveGoreMeshes : BoolProperty(name="Remove Gore Meshes", description = "Automatically delete all of the verticies with the gore material when loading a model", default = False)
     SaveBonePositions: BoolProperty(name="Save Animation Bone Positions", description = "Include bone positions in animation (may mess with additive animations being applied)", default = True)
     ImportArmature   : BoolProperty(name="Import Armatures", description = "Import unit armature data", default = True)
-    MergeArmatures   : BoolProperty(name="Merge Armatures", description = "Merge new armatures to the selected armature", default = True)
+    MergeArmatures   : BoolProperty(name="Merge Armatures", description = "Merge new armatures to the selected armature", default = False)
     ParentArmature   : BoolProperty(name="Parent Armatures", description = "Make imported armatures the parent of the imported mesh", default = True)
     SplitUVIslands   : BoolProperty(name="Split UV Islands", description = "Split mesh by UV islands when saving", default = False)
     # Search

--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1876,14 +1876,14 @@ def CreateModel(stingray_unit, id, Global_BoneNames):
                 skeletonObj = bpy.context.selected_objects[0]
             if skeletonObj and skeletonObj.type == 'ARMATURE':
                 armature = skeletonObj.data
-            if bpy.context.scene.Hd2ToolPanelSettings.MergeArmatures and armature != None:
+            if armature != None and (bpy.context.scene.Hd2ToolPanelSettings.MergeArmatures or armature.name.startswith(str(id))):
                 PrettyPrint(f"Merging to previous skeleton: {skeletonObj.name}")
             else:
                 PrettyPrint(f"Creating New Skeleton")
-                armature = bpy.data.armatures.new(f"{id}_skeleton{mesh.LodIndex}")
+                armature = bpy.data.armatures.new(f"{id}_skeleton")
                 armature.display_type = "OCTAHEDRAL"
                 armature.show_names = True
-                skeletonObj = bpy.data.objects.new(f"{id}_lod{mesh.LodIndex}_rig", armature)
+                skeletonObj = bpy.data.objects.new(f"{id}_rig", armature)
                 skeletonObj['BonesID'] = str(stingray_unit.BonesRef)
                 skeletonObj.show_in_front = True
                 


### PR DESCRIPTION
- Fix error where bone added to BoneInfo could sometimes be None
- Fix error in save object dump where callback could be unassigned
- Fix crashing on death after adding new bones
- Keep original bone scale data when saving bones
- Change Merge Armatures behavior:
  - All meshes in a unit will now use the same armature (the complete unit armature) whether or not Merge Armatures is enabled
  - Merge Armatures will still force merging of armatures between units
  - Merge Armatures set to off by default