### PR TITLE
native Linux functionality

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 __pycache__
 .vscode
+
+deps/*
+!deps/texconv.exe
+.python_version

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ The developers of the original version of the tool have stated that they are unl
 Download the [latest release build](https://github.com/Boxofbiscuits97/HD2SDK-CommunityEdition/releases) and install it into [Blender 4.0 to 4.3](https://www.blender.org/download/). 
 - Windows is the only officially supported operating system.
 - Linux has also been reported to work via Wine.
+  - To use on linux without wine, extract the latest linux build of [this texconv implementation](https://github.com/matyalatte/Texconv-Custom-DLL) to the `deps` folder in the addon's zip before installing.
 
 ## Usage
 We've taken the time to write a tutorial focused on armor modding which should assist those already moderately familiar with mesh modding and Blender in general. Unfortunately we do not have the means to provide constant support to anyone new to either, but in the event anyone should write a more in-depth tutorial, create a video tutorial, etc, we would be happy to feature it here if it's brought to our attention.

--- a/__init__.py
+++ b/__init__.py
@@ -14,6 +14,7 @@ from copy import deepcopy
 import copy
 from math import ceil
 from pathlib import Path
+import os
 import configparser
 import requests
 import json
@@ -75,16 +76,17 @@ from .constants import *
 #region Global Variables
 
 AddonPath = os.path.dirname(__file__)
+import platform
+Global_texconvbin        = "texconv" if platform.system() == "Linux" else "texconv.exe"
+Global_texconvpath       = f"{AddonPath}/deps/{Global_texconvbin}"
+Global_materialpath      = f"{AddonPath}/materials"
+Global_typehashpath      = f"{AddonPath}/hashlists/typehash.txt"
+Global_filehashpath      = f"{AddonPath}/hashlists/filehash.txt"
+Global_friendlynamespath = f"{AddonPath}/hashlists/friendlynames.txt"
 
-Global_texconvpath       = f"{AddonPath}\\deps\\texconv.exe"
-Global_materialpath      = f"{AddonPath}\\materials"
-Global_typehashpath      = f"{AddonPath}\\hashlists\\typehash.txt"
-Global_filehashpath      = f"{AddonPath}\\hashlists\\filehash.txt"
-Global_friendlynamespath = f"{AddonPath}\\hashlists\\friendlynames.txt"
-
-Global_archivehashpath   = f"{AddonPath}\\hashlists\\archivehashes.json"
-Global_variablespath     = f"{AddonPath}\\hashlists\\shadervariables.txt"
-Global_bonehashpath      = f"{AddonPath}\\hashlists\\bonehash.txt"
+Global_archivehashpath   = f"{AddonPath}/hashlists/archivehashes.json"
+Global_variablespath     = f"{AddonPath}/hashlists/shadervariables.txt"
+Global_bonehashpath      = f"{AddonPath}/hashlists/bonehash.txt"
 
 Global_defaultgamepath   = "C:\Program Files (x86)\Steam\steamapps\common\Helldivers 2\data\ "
 Global_defaultgamepath   = Global_defaultgamepath[:len(Global_defaultgamepath) - 1]
@@ -92,7 +94,6 @@ Global_gamepath          = ""
 Global_gamepathIsValid   = False
 Global_searchpath        = ""
 Global_configpath        = f"{AddonPath}.ini"
-Global_backslash         = "\-".replace("-", "")
 
 Global_Foldouts = []
 
@@ -1436,7 +1437,7 @@ def GenerateMaterialTextures(Entry):
                 if not os.path.exists(path) and ID.isnumeric():
                     PrettyPrint(f"Image not found. Attempting to find image: {ID} in temp folder.", 'WARN')
                     tempdir = tempfile.gettempdir()
-                    path = f"{tempdir}\\{ID}.png"
+                    path = f"{tempdir}/{ID}.png"
                 filepaths.append(path)
 
                 # enforce proper colorspace for abnormal stingray textures
@@ -1476,8 +1477,8 @@ def GenerateMaterialTextures(Entry):
 
 def BlendImageToStingrayTexture(image, StingrayTex):
     tempdir  = tempfile.gettempdir()
-    dds_path = f"{tempdir}\\blender_img.dds"
-    tga_path = f"{tempdir}\\blender_img.tga"
+    dds_path = f"{tempdir}/blender_img.dds"
+    tga_path = f"{tempdir}/blender_img.tga"
 
     image.file_format = 'TARGA_RAW'
     image.filepath_raw = tga_path
@@ -1502,8 +1503,8 @@ def LoadStingrayTexture(ID, TocData, GpuData, StreamData, Reload, MakeBlendObjec
 
     if MakeBlendObject and not (exists and not Reload):
         tempdir = tempfile.gettempdir()
-        dds_path = f"{tempdir}\\{ID}.dds"
-        png_path = f"{tempdir}\\{ID}.png"
+        dds_path = f"{tempdir}/{ID}.dds"
+        png_path = f"{tempdir}/{ID}.png"
 
         with open(dds_path, 'w+b') as f:
             f.write(dds)
@@ -1773,7 +1774,7 @@ class ChangeFilepathOperator(Operator, ImportHelper):
         filepath = self.filepath
         steamapps = "steamapps"
         if steamapps in filepath:
-            filepath = f"{filepath.partition(steamapps)[0]}steamapps\common\Helldivers 2\data\ "[:-1]
+            filepath = f"{filepath.partition(steamapps)[0]}steamapps/common/Helldivers 2/data/ "[:-1]
         else:
             self.report({'ERROR'}, f"Could not find steamapps folder in filepath: {filepath}")
             return{'CANCELLED'}
@@ -2083,11 +2084,11 @@ class ExportPatchAsZipOperator(Operator, ExportHelper):
         
         filepath = self.properties.filepath
         outputFilename = filepath.replace(".zip", "")
-        exportname = filepath.split(Global_backslash)[-1]
+        exportname = os.path.basename(filepath)
         
         patchName = Global_TocManager.ActivePatch.Name
-        tempPatchFolder = bpy.app.tempdir + "patchExport\\"
-        tempPatchFile = f"{tempPatchFolder}\{patchName}"
+        tempPatchFolder = bpy.app.tempdir + "patchExport/"
+        tempPatchFile = f"{tempPatchFolder}/{patchName}"
         PrettyPrint(f"Exporting in temp folder: {tempPatchFolder}")
 
         if not os.path.exists(tempPatchFolder):
@@ -2095,7 +2096,7 @@ class ExportPatchAsZipOperator(Operator, ExportHelper):
         Global_TocManager.ActivePatch.ToFile(tempPatchFile)
         shutil.make_archive(outputFilename, 'zip', tempPatchFolder)
         for file in os.listdir(tempPatchFolder):
-            path = f"{tempPatchFolder}\{file}"
+            path = f"{tempPatchFolder}/{file}"
             os.remove(path)
         os.removedirs(tempPatchFolder)
 
@@ -2865,11 +2866,11 @@ class ExportTexturePNGOperator(Operator, ExportHelper):
         if Entry != None:
             tempdir = tempfile.gettempdir()
             for i in range(Entry.LoadedData.ArraySize):
-                filename = self.filepath.split(Global_backslash)[-1]
+                filename = os.path.basename(self.filepath)
                 directory = self.filepath.replace(filename, "")
                 filename = filename.replace(".png", "")
                 layer = "" if Entry.LoadedData.ArraySize == 1 else f"_layer{i}"
-                dds_path = f"{tempdir}\\{filename}{layer}.dds"
+                dds_path = f"{tempdir}/{filename}{layer}.dds"
                 with open(dds_path, 'w+b') as f:
                     if Entry.LoadedData.ArraySize == 1:
                         f.write(Entry.LoadedData.ToDDS())
@@ -2932,11 +2933,11 @@ class BatchExportTexturePNGOperator(Operator):
             Entry = Global_TocManager.GetEntry(EntryID, TexID)
             if Entry != None:
                 tempdir = tempfile.gettempdir()
-                dds_path = f"{tempdir}\\{EntryID}.dds"
+                dds_path = f"{tempdir}/{EntryID}.dds"
                 with open(dds_path, 'w+b') as f:
                     f.write(Entry.LoadedData.ToDDS())
                 subprocess.run([Global_texconvpath, "-y", "-o", self.directory, "-ft", "png", "-f", "R8G8B8A8_UNORM", "-alpha", dds_path])
-                filepath = f"{self.directory}\\{EntryID}.png"
+                filepath = f"{self.directory}/{EntryID}.png"
                 if os.path.isfile(filepath):
                     exportedfiles += 1
                 else:
@@ -3001,9 +3002,8 @@ def SaveImagePNG(filepath, object_id):
             PrettyPrint(filepath)
             PrettyPrint(StingrayTex.Format)
             subprocess.run([Global_texconvpath, "-y", "-o", tempdir, "-ft", "dds", "-dx10", "-f", StingrayTex.Format, "-sepalpha", "-alpha", filepath], stdout=subprocess.DEVNULL, stderr=subprocess.STDOUT)
-            nameIndex = filepath.rfind("\.".strip(".")) + 1
-            fileName = filepath[nameIndex:].replace(".png", ".dds")
-            dds_path = f"{tempdir}\\{fileName}"
+            fileName = os.path.basename(filepath).replace(".png", ".dds")
+            dds_path = f"{tempdir}/{fileName}"
             PrettyPrint(dds_path)
             if not os.path.exists(dds_path):
                 raise Exception(f"Failed to convert to dds texture for: {dds_path}")
@@ -3118,7 +3118,7 @@ class SetMaterialTemplateOperator(Operator):
         return context.window_manager.invoke_props_dialog(self)
 
 def CreateModdedMaterial(template, ID=None):
-    path = f"{Global_materialpath}\\{template}.material"
+    path = f"{Global_materialpath}/{template}.material"
     if not os.path.exists(path):
         raise Exception(f"Selected material template: {template} does not exist")
 


### PR DESCRIPTION
I plan to use this SDK on linux and don't really want to wrangle blender under wine. These are the changes needed for this to work. (already done)

The platform-dependent stuff is:
1. texconv
2. path handling

My changes to address these are:
1. There is a cross-platform version of texconv available [here](https://github.com/matyalatte/Texconv-Custom-DLL) that does the job. Dropping it into the deps folder and setting Global_texconvpath based on `platform.system()` is good enough. This doesn't need to be packaged with the main release since it's niche and easy enough to add manually. A note in the README to download it is probably sufficient.

2. I have already made the changes necessary to make path handling platform-independent for my own purposes. They include changing path-related usages of "\\" to "/" and replacing manual path splitting with the appropriate function from os.path. Windows understands posix paths, (using /) so these changes won't affect the windows side.

Also, going forward, I understand if you don't want to commit to supporting Linux yourself. I'll probably notice if something breaks in the future and submit a pr if you're ok with that.