### PR TITLE
fix error in slim module

### DIFF
--- a/utils/slim.py
+++ b/utils/slim.py
@@ -154,6 +154,10 @@ def init_bundle_mapping():
             bundle_name = os.path.basename(filename)
             bundle_offsets[bundle_name] = {}
             with open(os.path.join(game_data_folder, bundle_name), 'rb') as bundle:
+                magic = int.from_bytes(bundle.read(4), byteorder="little")
+                if magic != 0x52415344:
+                    del bundle_offsets[bundle_name]
+                    continue
                 bundle.seek(8)
                 num_chunks = read_int(bundle) # num data chunks
                 bundle.seek(0x20)


### PR DESCRIPTION
- fix error where having old uncompressed files mixed in with compressed files could allocate huge amounts of memory
- Add check that the file magic of any files read is DSAR before treating them as compressed files