### PR TITLE
Fix animation custom bones

### DIFF
--- a/stingray/animation.py
+++ b/stingray/animation.py
@@ -448,10 +448,14 @@ class StingrayAnimation:
         initial_state.compress_position = 0
         initial_state.compress_rotation = 0
         initial_state.compress_scale = 0
-        if bone.parent:
-            translation, rotation, scale = (bone.parent.matrix.inverted() @ bone.matrix).decompose()
+        if self.is_additive_animation:
+            mat = mathutils.Matrix.Identity(4)
         else:
-            translation, rotation, scale = bone.matrix.decompose()
+            if bone.parent is not None:
+                mat = (bone.parent.matrix.inverted() @ bone.matrix)
+            else:
+                mat = bone.matrix
+        translation, rotation, scale = mat.decompose()
         initial_state.position = translation.to_tuple()
         initial_state.rotation = (rotation[1], rotation[2], rotation[3], rotation[0])
         initial_state.scale = [1, 1, 1] if not self.is_additive_animation else [0, 0, 0]

--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1809,13 +1809,14 @@ def GetMeshData(og_object, Global_TocManager, Global_BoneNames):
                     bone_data.BoneHashes.pop(bone_index)
                     bone_data.Names.pop(bone_index)
                 bone_data.NumNames -= len(removed_bones)
-                for blend_mask in state_machine_data.blend_masks:
-                    blend_mask.bone_count -= len(removed_bones)
-                    for bone_index in removed_bone_indices:
-                        try:
-                            blend_mask.bone_weights.pop(bone_index)
-                        except IndexError: # happens when removing a custom animated bone
-                            pass
+                if state_machine_data:
+                    for blend_mask in state_machine_data.blend_masks:
+                        blend_mask.bone_count -= len(removed_bones)
+                        for bone_index in removed_bone_indices:
+                            try:
+                                blend_mask.bone_weights.pop(bone_index)
+                            except IndexError: # happens when removing a custom animated bone
+                                pass
             
             # Add new animated bones
             if added_bones:
@@ -1829,19 +1830,20 @@ def GetMeshData(og_object, Global_TocManager, Global_BoneNames):
                     
             # remove and add bones from animations
             if added_bones or removed_bones:
-                for animation in state_machine_data.animation_ids:
-                    animation_data = Global_TocManager.GetEntry(animation, AnimationID, IgnorePatch=False, SearchAll=True)
-                    if not animation_data.IsLoaded:
-                        animation_data.Load(False, False)
-                    animation_data.LoadedData.remove_bone_list(removed_bone_indices)
-                    for bone in added_bones:
-                        animation_data.LoadedData.add_bone(bone)
-                    animation_data.LoadedData.finish_bone_update()
-                    Global_TocManager.Save(animation, AnimationID)
+                if state_machine_data:
+                    for animation in state_machine_data.animation_ids:
+                        animation_data = Global_TocManager.GetEntry(animation, AnimationID, IgnorePatch=False, SearchAll=True)
+                        if not animation_data.IsLoaded:
+                            animation_data.Load(False, False)
+                        animation_data.LoadedData.remove_bone_list(removed_bone_indices)
+                        for bone in added_bones:
+                            animation_data.LoadedData.add_bone(bone)
+                        animation_data.LoadedData.finish_bone_update()
+                        Global_TocManager.Save(animation, AnimationID)
                     
             if added_bones or removed_bones:
-                bone_entry.Save()
-                state_machine_entry.Save()
+                if bone_entry: bone_entry.Save()
+                if state_machine_entry: state_machine_entry.Save()
                     
         # --- END ANIMATED BONE DATA ---
         

--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -1797,50 +1797,51 @@ def GetMeshData(og_object, Global_TocManager, Global_BoneNames):
         
         # --- MAKE CHANGES TO ANIMATED BONE DATA ---
         
-        added_bones = [bone for bone in armature_obj.data.edit_bones if bone.get('Animated', False) and compute_bone_name_hash(bone.name) not in bone_data.BoneHashes]
-        removed_bones = [bone for bone in armature_obj.data.edit_bones if not bone.get('Animated', False) and compute_bone_name_hash(bone.name) in bone_data.BoneHashes]
-        removed_bone_indices = [bone_data.BoneHashes.index(compute_bone_name_hash(bone.name)) for bone in removed_bones]
-        removed_bone_indices.sort(reverse=True)
-        
-        # Remove deleted animated bones
-        if removed_bones:
-            for bone_index in removed_bone_indices:
-                bone_data.BoneHashes.pop(bone_index)
-                bone_data.Names.pop(bone_index)
-            bone_data.NumNames -= len(removed_bones)
-            for blend_mask in state_machine_data.blend_masks:
-                blend_mask.bone_count -= len(removed_bones)
+        if bone_data:
+            added_bones = [bone for bone in armature_obj.data.edit_bones if bone.get('Animated', False) and compute_bone_name_hash(bone.name) not in bone_data.BoneHashes]
+            removed_bones = [bone for bone in armature_obj.data.edit_bones if not bone.get('Animated', False) and compute_bone_name_hash(bone.name) in bone_data.BoneHashes]
+            removed_bone_indices = [bone_data.BoneHashes.index(compute_bone_name_hash(bone.name)) for bone in removed_bones]
+            removed_bone_indices.sort(reverse=True)
+            
+            # Remove deleted animated bones
+            if removed_bones:
                 for bone_index in removed_bone_indices:
-                    try:
-                        blend_mask.bone_weights.pop(bone_index)
-                    except IndexError: # happens when removing a custom animated bone
-                        pass
-        
-        # Add new animated bones
-        if added_bones:
-            bone_data.BoneHashes.extend([compute_bone_name_hash(bone.name) for bone in added_bones])
-            bone_data.Names.extend([bone.name for bone in added_bones])
-            bone_data.NumNames += len(added_bones)
-            if state_machine_data:
+                    bone_data.BoneHashes.pop(bone_index)
+                    bone_data.Names.pop(bone_index)
+                bone_data.NumNames -= len(removed_bones)
                 for blend_mask in state_machine_data.blend_masks:
-                    blend_mask.bone_count += len(added_bones)
-                    blend_mask.bone_weights.extend([0.0 for bone in added_bones])
-                
-        # remove and add bones from animations
-        if added_bones or removed_bones:
-            for animation in state_machine_data.animation_ids:
-                animation_data = Global_TocManager.GetEntry(animation, AnimationID, IgnorePatch=False, SearchAll=True)
-                if not animation_data.IsLoaded:
-                    animation_data.Load(False, False)
-                animation_data.LoadedData.remove_bone_list(removed_bone_indices)
-                for bone in added_bones:
-                    animation_data.LoadedData.add_bone(bone)
-                animation_data.LoadedData.finish_bone_update()
-                Global_TocManager.Save(animation, AnimationID)
-                
-        if added_bones or removed_bones:
-            bone_entry.Save()
-            state_machine_entry.Save()
+                    blend_mask.bone_count -= len(removed_bones)
+                    for bone_index in removed_bone_indices:
+                        try:
+                            blend_mask.bone_weights.pop(bone_index)
+                        except IndexError: # happens when removing a custom animated bone
+                            pass
+            
+            # Add new animated bones
+            if added_bones:
+                bone_data.BoneHashes.extend([compute_bone_name_hash(bone.name) for bone in added_bones])
+                bone_data.Names.extend([bone.name for bone in added_bones])
+                bone_data.NumNames += len(added_bones)
+                if state_machine_data:
+                    for blend_mask in state_machine_data.blend_masks:
+                        blend_mask.bone_count += len(added_bones)
+                        blend_mask.bone_weights.extend([0.0 for bone in added_bones])
+                    
+            # remove and add bones from animations
+            if added_bones or removed_bones:
+                for animation in state_machine_data.animation_ids:
+                    animation_data = Global_TocManager.GetEntry(animation, AnimationID, IgnorePatch=False, SearchAll=True)
+                    if not animation_data.IsLoaded:
+                        animation_data.Load(False, False)
+                    animation_data.LoadedData.remove_bone_list(removed_bone_indices)
+                    for bone in added_bones:
+                        animation_data.LoadedData.add_bone(bone)
+                    animation_data.LoadedData.finish_bone_update()
+                    Global_TocManager.Save(animation, AnimationID)
+                    
+            if added_bones or removed_bones:
+                bone_entry.Save()
+                state_machine_entry.Save()
                     
         # --- END ANIMATED BONE DATA ---
         

--- a/stingray/unit.py
+++ b/stingray/unit.py
@@ -2085,9 +2085,15 @@ def GetMeshData(og_object, Global_TocManager, Global_BoneNames):
     #bpy.ops.object.mode_set(mode='OBJECT')
     # get faces
     temp_faces = [[] for n in range(len(object.material_slots))]
+    faces_skipped = 0
     for f in mesh.polygons:
-        temp_faces[f.material_index].append([f.vertices[0], f.vertices[1], f.vertices[2]])
-        materials[f.material_index].NumIndices += 3
+        try:
+            temp_faces[f.material_index].append([f.vertices[0], f.vertices[1], f.vertices[2]])
+            materials[f.material_index].NumIndices += 3
+        except IndexError:
+            faces_skipped += 1
+    if faces_skipped:
+        PrettyPrint(f"Skipping {faces_skipped} faces that were not assigned a material...", "warn")
     for tmp in temp_faces: faces.extend(tmp)
 
     NewMesh = RawMeshClass()


### PR DESCRIPTION
- Fix issue where added custom bones default rotation was incorrect for additive animations
- Fix issue where saving a mesh containing faces without an assigned material would cause an error (these faces are now skipped with a warning)