### PR TITLE
Fix Blender add-on unload cleanup

### DIFF
--- a/__init__.py
+++ b/__init__.py
@@ -3979,16 +3979,6 @@ class LatestReleaseOperator(Operator):
         webbrowser.open(url, new=0, autoraise=True)
         return{'FINISHED'}
 
-class ViewChangelogOperator(Operator):
-    bl_label  = "View SDK Changelog"
-    bl_idname = "helldiver2.latest_release"
-    bl_description = "Opens The Github Page to the latest changelog"
-
-    def execute(self, context):
-        url = "https://github.com/Boxofbiscuits97/HD2SDK-CommunityEdition/releases/latest"
-        webbrowser.open(url, new=0, autoraise=True)
-        return{'FINISHED'}
-        
 class AutoUpdateOperator(Operator):
     bl_label = "Auto Update Helldivers 2 SDK"
     bl_idname = "helldiver2.update"
@@ -5582,7 +5572,6 @@ classes = (
     StateMachineSaveOperator,
     SetBoneRagdollOperator,
     AddLightOperator,
-    ViewChangelogOperator,
     LoadPlayerAvatarOperator,
     StateMachineAnimationIDOperator,
     ImportXAMLOperator,
@@ -5628,19 +5617,20 @@ def register():
     bpy.types.Scene.new_id_entry = StringProperty(name="new_id_entry", default="")
 
 def unregister():
+    del bpy.types.Scene.new_id_entry
+    for t in reversed(Global_TypeIDs):
+        delattr(bpy.types.Scene, f"index_{t}_dummy")
+        delattr(bpy.types.Scene, f"filter_{t}")
+        delattr(bpy.types.Scene, f"index_{t}")
+        delattr(bpy.types.Scene, f"list_{t}")
+    bpy.utils.unregister_class(ListItem)
+    bpy.utils.unregister_class(MY_UL_List)
+    bpy.types.VIEW3D_MT_armature_context_menu.remove(CustomBoneContext)
+    bpy.types.VIEW3D_MT_object_context_menu.remove(CustomPropertyContext)
     bpy.utils.unregister_class(WM_MT_button_context)
     del Scene.Hd2ToolPanelSettings
     for cls in reversed(classes):
         bpy.utils.unregister_class(cls)
-    bpy.types.VIEW3D_MT_object_context_menu.remove(CustomPropertyContext)
-    bpy.types.VIEW3D_MT_armature_context_menu.remove(CustomBoneContext)
-    for t in Global_TypeIDs:
-        delattr(bpy.types.Scene, f"list_{t}")
-        delattr(bpy.types.Scene, f"index_{t}")
-        delattr(bpy.types.Scene, f"filter_{t}")
-        delattr(bpy.types.Scene, f"index_{t}_dummy")
-    bpy.utils.unregister_class(MY_UL_List)
-    bpy.utils.unregister_class(ListItem)
 
 if __name__=="__main__":
     register()

--- a/__init__.py
+++ b/__init__.py
@@ -3970,9 +3970,9 @@ class GithubOperator(Operator):
         return{'FINISHED'}
     
 class LatestReleaseOperator(Operator):
-    bl_label  = "Update Helldivers 2 SDK"
+    bl_label  = "View SDK Changelog"
     bl_idname = "helldiver2.latest_release"
-    bl_description = "Opens The Github Page to the latest release"
+    bl_description = "Opens The Github Page to the latest changelog"
 
     def execute(self, context):
         url = "https://github.com/Boxofbiscuits97/HD2SDK-CommunityEdition/releases/latest"

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -62,7 +62,6 @@ Global_TypeIDs = [
     0x9e5c3cc74575aeb5, #shader_library_group
     0xe5ee32a477239a93, #shader_library
     0x05106b81dcd58a13, #runtime_font
-    0x0d972bab10b40fd3, #strings
     0x1d59bd6687db6b33, #ragdoll_profile
     0x2a0a70acfe476e1d, #ah_bin
     0x57a13425279979d7, #ik_skeleton


### PR DESCRIPTION
Fixes add-on disable/unload failures caused by registration state that cannot be cleanly reversed.

- Remove the redundant `ViewChangelogOperator`; it duplicates `LatestReleaseOperator`, including the same `helldiver2.latest_release` operator ID and release URL. Preserve the existing changelog label and tooltip on `LatestReleaseOperator`, so the user-facing behavior stays unchanged.
- Remove the duplicate `strings` entry from `Global_TypeIDs`, preventing generated `Scene` properties from being registered and deleted twice.
- Make `unregister()` reverse the setup order and delete `Scene.new_id_entry`, so add-on-owned RNA state is fully removed before its supporting classes are unregistered.

closes #117 